### PR TITLE
Fix origin access identity

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,49 +1,49 @@
 output "id" {
   description = "The identifier for the distribution."
-  value       = "${aws_cloudfront_distribution.cf_distribution.id}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.id, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.id, list("")), 0)}"
 }
 
 output "arn" {
   description = "The ARN (Amazon Resource Name) for the distribution."
-  value       = "${aws_cloudfront_distribution.cf_distribution.arn}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.arn, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.arn, list("")), 0)}"
 }
 
 output "caller_reference" {
   description = "Internal value used by CloudFront to allow future updates to the distribution configuration."
-  value       = "${aws_cloudfront_distribution.cf_distribution.caller_reference}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.caller_reference, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.caller_reference, list("")), 0)}"
 }
 
 output "status" {
   description = "The current status of the distribution."
-  value       = "${aws_cloudfront_distribution.cf_distribution.status}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.status, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.status, list("")), 0)}"
 }
 
 output "active_trusted_signers" {
   description = "The key pair IDs that CloudFront is aware of for each trusted signer, if the distribution is set up to serve private content with signed URLs."
-  value       = "${aws_cloudfront_distribution.cf_distribution.active_trusted_signers}"
+  value       = "${local.active_trusted_signers[0]}"
 }
 
 output "domain_name" {
   description = "The domain name corresponding to the distribution."
-  value       = "${aws_cloudfront_distribution.cf_distribution.domain_name}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.domain_name, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.domain_name, list("")), 0)}"
 }
 
 output "last_modified_time" {
   description = "The date and time the distribution was last modified."
-  value       = "${aws_cloudfront_distribution.cf_distribution.last_modified_time}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.last_modified_time, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.last_modified_time), 0)}"
 }
 
 output "in_progress_validation_batches" {
   description = "The number of invalidation batches currently in progress."
-  value       = "${aws_cloudfront_distribution.cf_distribution.in_progress_validation_batches}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.in_progress_validation_batches, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.in_progress_validation_batches, list("")), 0)}"
 }
 
 output "etag" {
   description = "The current version of the distribution's information."
-  value       = "${aws_cloudfront_distribution.cf_distribution.etag}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.etag, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.etag, list("")), 0)}"
 }
 
 output "hosted_zone_id" {
   description = "The CloudFront Route 53 zone ID that can be used to route an Alias Resource Record Set to."
-  value       = "${aws_cloudfront_distribution.cf_distribution.hosted_zone_id}"
+  value       = "${element(coalescelist(aws_cloudfront_distribution.cf_distribution.*.hosted_zone_id, aws_cloudfront_distribution.cf_distribution_no_s3_origin_config.*.hosted_zone_id, list("")), 0)}"
 }

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -57,7 +57,8 @@ module "cloudfront_s3_origin" {
   aliases = ["testdomain.${random_string.cloudfront_rstring.result}.example.com"]
 
   # Origin access id
-  origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+  origin_access_identity          = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+  origin_access_identity_provided = true
 
   # default cache behavior
   allowed_methods  = ["GET", "HEAD"]

--- a/variables.tf
+++ b/variables.tf
@@ -226,6 +226,12 @@ variable "origin_access_identity" {
   default     = ""
 }
 
+variable "origin_access_identity_provided" {
+  description = "origin_access_identity has been provided"
+  type        = "string"
+  default     = false
+}
+
 # Restrictions
 variable "locations" {
   description = "The two-letter, uppercase country code for a country that you want to include in your blacklist or whitelist."


### PR DESCRIPTION
Reference: https://trello.com/c/Tl3gRJxc/1021-cloudfronts3origin-module-defaults-to-being-updated-on-every-run and https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/159

- Add conditionals around cloudfront distribution depending on whether or not an origin access identity has been provided.
- Modify variable outputs to support resource conditionals.