### PR TITLE
Cname cert fix

### DIFF
--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -54,7 +54,7 @@ module "cloudfront_s3_origin" {
   default_root_object = "index.html"
 
   bucket_logging = false
-  
+
   # Origin access id
   origin_access_identity          = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   origin_access_identity_provided = true

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -54,9 +54,7 @@ module "cloudfront_s3_origin" {
   default_root_object = "index.html"
 
   bucket_logging = false
-
-  aliases = ["testdomain.${random_string.cloudfront_rstring.result}.example.com"]
-
+  
   # Origin access id
   origin_access_identity          = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   origin_access_identity_provided = true


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section
https://jira.rax.io/browse/MPCSUPENG-298

##### Summary of change(s):
per https://aws.amazon.com/about-aws/whats-new/2019/04/amazon-cloudfront-enhances-the-security-for-adding-alternate-domain-names-to-a-distribution/ you now have to use a matching valid SSL cert for any cname aliases. Removed from testing.

##### Reason for Change(s):

per https://aws.amazon.com/about-aws/whats-new/2019/04/amazon-cloudfront-enhances-the-security-for-adding-alternate-domain-names-to-a-distribution/ you now have to use a matching valid SSL cert for any cname aliases. Removed from testing.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
n/a
##### Do examples need to be updated based on changes?

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
